### PR TITLE
Update datapoints code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi",
 ]
@@ -2258,6 +2259,7 @@ dependencies = [
  "serialport",
  "tee_readwrite",
  "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -2642,6 +2644,15 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "vcpkg"

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -21,5 +21,6 @@ thiserror = "1.0.30"
 rodio = "0.15.0"
 rand = "0.8.5"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 tee_readwrite = "0.1.0"
+uuid = { version = "1.1.0", features = ["serde"] }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -657,7 +657,7 @@ fn main() {
                         };
                         let _ = datapoints_sender.try_send(Datapoint::Twist(TwistDatapoint {
                             rotation: twist.to_string(),
-                            updated_cube_state: cube.serialise(),
+                            cube_state: cube.serialise(),
                             game_id: game_state.game_id(),
                             play_time_milliseconds,
                             timestamp: Utc::now(),
@@ -689,6 +689,7 @@ fn main() {
                                         game_id: game_state.game_id().unwrap(),
                                         play_time_milliseconds: t.try_into().unwrap_or(u32::MAX),
                                         new_top_score,
+                                        cube_state: cube.serialise(),
                                         timestamp: Utc::now(),
                                     }));
                                 }

--- a/service/src/schema.rs
+++ b/service/src/schema.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 #[serde(rename_all = "snake_case")]
 pub enum Datapoint {
     GameStart(GameStartDatapoint),
-    GameInspection(GameInspectionDatapoint),
     Twist(TwistDatapoint),
     GameSolve(GameSolveDatapoint),
 }
@@ -22,16 +21,6 @@ pub struct GameStartDatapoint {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GameInspectionDatapoint {
-    // Unique identifier of this game
-    pub game_id: String,
-    // How long the inspection period lasted, in milliseconds
-    pub inspection_milliseconds_duration: u32,
-    // Time since the unix epoch
-    pub timestamp: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TwistDatapoint {
     // The cube rotation in standard notation https://ruwix.com/the-rubiks-cube/notation/
     pub rotation: String,
@@ -39,8 +28,8 @@ pub struct TwistDatapoint {
     pub updated_cube_state: String,
     // Game unique ID (only if this twist happened during an active game)
     pub game_id: Option<String>,
-    // How long since the inspection period ended, in milliseconds
-    pub play_milliseconds_elapsed: Option<u32>,
+    // How long the solve attempt has taken so far, in milliseconds
+    pub play_time_milliseconds: Option<u32>,
     // Time since the unix epoch
     pub timestamp: DateTime<Utc>,
 }
@@ -49,12 +38,10 @@ pub struct TwistDatapoint {
 pub struct GameSolveDatapoint {
     // Unique identifier of this game
     pub game_id: String,
-    // How long the inspection period lasted, in milliseconds
-    pub inspection_milliseconds_duration: u32,
-    // How long the play period lasted, in milliseconds
-    pub play_milliseconds_duration: u32,
-    // How many twists were performed during the game
-    pub number_of_twists: u32,
+    // How long the solve took, in milliseconds
+    pub play_time_milliseconds: u32,
+    // Whether the cube recognised this as a new top score
+    pub new_top_score: bool,
     // Time since the unix epoch
     pub timestamp: DateTime<Utc>,
 }

--- a/service/src/schema.rs
+++ b/service/src/schema.rs
@@ -1,0 +1,60 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Datapoint {
+    GameStart(GameStartDatapoint),
+    GameInspection(GameInspectionDatapoint),
+    Twist(TwistDatapoint),
+    GameSolve(GameSolveDatapoint),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameStartDatapoint {
+    // Unique identifier of this game
+    pub game_id: String,
+    // Starting cube face positions
+    pub cube_state: String,
+    // Time since the unix epoch
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameInspectionDatapoint {
+    // Unique identifier of this game
+    pub game_id: String,
+    // How long the inspection period lasted, in milliseconds
+    pub inspection_milliseconds_duration: u32,
+    // Time since the unix epoch
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TwistDatapoint {
+    // The cube rotation in standard notation https://ruwix.com/the-rubiks-cube/notation/
+    pub rotation: String,
+    // New cube face positions
+    pub updated_cube_state: String,
+    // Game unique ID (only if this twist happened during an active game)
+    pub game_id: Option<String>,
+    // How long since the inspection period ended, in milliseconds
+    pub play_milliseconds_elapsed: Option<u32>,
+    // Time since the unix epoch
+    pub timestamp: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GameSolveDatapoint {
+    // Unique identifier of this game
+    pub game_id: String,
+    // How long the inspection period lasted, in milliseconds
+    pub inspection_milliseconds_duration: u32,
+    // How long the play period lasted, in milliseconds
+    pub play_milliseconds_duration: u32,
+    // How many twists were performed during the game
+    pub number_of_twists: u32,
+    // Time since the unix epoch
+    pub timestamp: DateTime<Utc>,
+}

--- a/service/src/schema.rs
+++ b/service/src/schema.rs
@@ -10,6 +10,7 @@ pub enum Datapoint {
     GameSolve(GameSolveDatapoint),
 }
 
+// Records new games starting with a randomised cube
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameStartDatapoint {
     // Unique identifier of this game
@@ -20,12 +21,13 @@ pub struct GameStartDatapoint {
     pub timestamp: DateTime<Utc>,
 }
 
+// Records cube twists (rotations) and whether they are part of a game
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TwistDatapoint {
     // The cube rotation in standard notation https://ruwix.com/the-rubiks-cube/notation/
     pub rotation: String,
     // New cube face positions
-    pub updated_cube_state: String,
+    pub cube_state: String,
     // Game unique ID (only if this twist happened during an active game)
     pub game_id: Option<String>,
     // How long the solve attempt has taken so far, in milliseconds
@@ -34,6 +36,7 @@ pub struct TwistDatapoint {
     pub timestamp: DateTime<Utc>,
 }
 
+// Records successful solves starting from a randomised cube
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GameSolveDatapoint {
     // Unique identifier of this game
@@ -42,6 +45,8 @@ pub struct GameSolveDatapoint {
     pub play_time_milliseconds: u32,
     // Whether the cube recognised this as a new top score
     pub new_top_score: bool,
+    // Solved cube face positions
+    pub cube_state: String,
     // Time since the unix epoch
     pub timestamp: DateTime<Utc>,
 }


### PR DESCRIPTION
This commit brings the `Datapoint` code up to date with what we're doing in the Clickhouse DB. We start recording events for game starts, twists and game solves. It's not perfect but it's hopefully enough to really understand gameplay :)

In a future PR I'm hoping to bring the Cloudflare Worker code (used as a proxy between the Cube and the DB) and the Clickhouse DB schema into this repo.