### PR TITLE
Move datapoints into separate package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "datapoints"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serde",
+]
+
+[[package]]
 name = "device"
 version = "0.1.0"
 dependencies = [
@@ -2261,6 +2269,7 @@ dependencies = [
  "chrono",
  "clap 3.1.5",
  "cube_model",
+ "datapoints",
  "game_timer",
  "pest",
  "plain_authentic_commands",
@@ -2272,7 +2281,6 @@ dependencies = [
  "serialport",
  "tee_readwrite",
  "thiserror",
- "uuid",
 ]
 
 [[package]]
@@ -2657,15 +2665,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "uuid"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "vcpkg"

--- a/datapoints/Cargo.toml
+++ b/datapoints/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "datapoints"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }

--- a/datapoints/schema.sql
+++ b/datapoints/schema.sql
@@ -1,0 +1,38 @@
+-- ClickHouse schema for the Giant LED Cube.
+-- More information on ClickHouse schemas:
+--   https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree
+--   https://clickhouse.com/docs/en/sql-reference
+
+CREATE TABLE game_starts (
+    game_id String COMMENT 'Unique identifier of this game',
+    cube_state String COMMENT 'Starting cube face positions',
+    timestamp DateTime64(6, 'UTC') COMMENT 'Milliseconds since the unix epoch'
+) ENGINE MergeTree() 
+  PARTITION BY toYYYYMM(timestamp) 
+  ORDER BY (timestamp, game_id)
+  SETTINGS index_granularity=8192
+  COMMENT 'Records new games starting with a randomised cube';
+
+CREATE TABLE twists (
+    rotation String COMMENT 'The cube rotation in standard notation https://ruwix.com/the-rubiks-cube/notation/',
+    cube_state String COMMENT 'Updated cube face positions',
+    game_id Nullable(String) COMMENT 'Game unique ID (only if this twist happened during an active game)',
+    play_time_milliseconds Nullable(UInt32) COMMENT 'How long the solve attempt has taken so far, in milliseconds',
+    timestamp DateTime64(6, 'UTC') COMMENT 'Milliseconds since the unix epoch'
+) ENGINE MergeTree() 
+  PARTITION BY toYYYYMM(timestamp) 
+  ORDER BY (timestamp)
+  SETTINGS index_granularity=8192
+  COMMENT 'Records cube twists (rotations) and whether they are part of a game';
+
+CREATE TABLE game_solves (
+    game_id String COMMENT 'Unique identifier of this game',
+    play_time_milliseconds UInt32 COMMENT 'How long the solve took, in milliseconds',
+    new_top_score Bool COMMENT 'Whether the cube recognised this as a new top score',
+    cube_state String COMMENT 'Solved cube face positions',
+    timestamp DateTime64(6, 'UTC') COMMENT 'Milliseconds since the unix epoch'
+) ENGINE MergeTree() 
+  PARTITION BY toYYYYMM(timestamp) 
+  ORDER BY (timestamp, game_id)
+  SETTINGS index_granularity=8192
+  COMMENT 'Records successful solves starting from a randomised cube';

--- a/datapoints/src/lib.rs
+++ b/datapoints/src/lib.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -14,6 +14,7 @@ pest = "2.0"
 plain_authentic_commands = { path="../plain_authentic_commands", features = ["challenge"] }
 cube_model = { path="../cube_model" }
 game_timer = { path="../game_timer" }
+datapoints = { path="../datapoints" }
 serialport = "4.0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -23,4 +24,3 @@ rand = "0.8.5"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 chrono = { version = "0.4", features = ["serde"] }
 tee_readwrite = "0.1.0"
-uuid = { version = "1.1.0", features = ["serde"] }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -17,14 +17,13 @@ use std::cmp::min;
 use std::fmt::{self,Display};
 
 use game_timer::TimerState;
+use datapoints::{Datapoint, GameStartDatapoint, TwistDatapoint, GameSolveDatapoint};
 
 use rodio::{Decoder, OutputStream, source::Source, source::Buffered};
 use rand::Rng;
 use std::io::Cursor;
 use chrono::Utc;
 
-mod schema;
-use schema::{Datapoint, GameStartDatapoint, TwistDatapoint, GameSolveDatapoint};
 
 #[derive(CLIParser, Debug)]
 struct Args{


### PR DESCRIPTION
So that we can re-use the code outside of `service` (e.g. in Cloudflare Workers or by EMFCamp peoples.)

Also removes crates we no longer need, and includes the ClickHouse SQL schema.