### PR TITLE
Use UUIDs for Game IDs and fix their use in Twist datapoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,9 @@ dependencies = [
 [[package]]
 name = "game_timer"
 version = "0.1.0"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "generic-array"
@@ -2665,6 +2668,16 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
+dependencies = [
+ "getrandom",
+ "rand",
+]
 
 [[package]]
 name = "vcpkg"

--- a/game_timer/Cargo.toml
+++ b/game_timer/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+uuid = { version = "1.1.0", features = ["v4", "fast-rng"] }

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -653,14 +653,16 @@ fn main() {
                         let _ignored = sound_sender.send(Sound::Twist());
                         cube.twist(twist);
 
-                        let play_time_milliseconds = match game_state.game_id() {
-                            Some(_) => game_state.solve_so_far().as_millis().try_into().ok(),
-                            None => None,
-                        };
+                        let mut game_id = None;
+                        let mut play_time_milliseconds = None;
+                        if game_state.is_started() && !game_state.is_ended() {
+                            game_id = game_state.game_id();
+                            play_time_milliseconds = game_state.solve_so_far().as_millis().try_into().ok();
+                        }
                         let _ = datapoints_sender.try_send(Datapoint::Twist(TwistDatapoint {
                             rotation: twist.to_string(),
                             cube_state: cube.serialise(),
-                            game_id: game_state.game_id(),
+                            game_id,
                             play_time_milliseconds,
                             timestamp: Utc::now(),
                         }));

--- a/service/src/main.rs
+++ b/service/src/main.rs
@@ -611,7 +611,7 @@ fn main() {
                                 sender.send(StreamEvent::SyncTimers(game_state.serialise()))?;
                             }
                             let _ = datapoints_sender.try_send(Datapoint::GameStart(GameStartDatapoint {
-                                game_id: game_state.game_id().unwrap(),
+                                game_id: game_state.game_id().unwrap().to_string(),
                                 cube_state: cube.serialise(),
                                 timestamp: Utc::now(),
                             }));
@@ -656,7 +656,7 @@ fn main() {
                         let mut game_id = None;
                         let mut play_time_milliseconds = None;
                         if game_state.is_started() && !game_state.is_ended() {
-                            game_id = game_state.game_id();
+                            game_id = game_state.game_id().map(|id| id.to_string());
                             play_time_milliseconds = game_state.solve_so_far().as_millis().try_into().ok();
                         }
                         let _ = datapoints_sender.try_send(Datapoint::Twist(TwistDatapoint {
@@ -692,7 +692,7 @@ fn main() {
                                         }
                                     }
                                     let _ = datapoints_sender.try_send(Datapoint::GameSolve(GameSolveDatapoint {
-                                        game_id: game_state.game_id().unwrap(),
+                                        game_id: game_state.game_id().unwrap().to_string(),
                                         play_time_milliseconds: t.try_into().unwrap_or(u32::MAX),
                                         new_top_score,
                                         cube_state: cube.serialise(),


### PR DESCRIPTION
Does exactly what the description says - see commit messages and diffs for more info.